### PR TITLE
Throw original to keep stack

### DIFF
--- a/cli-exakvdocsign/Program.cs
+++ b/cli-exakvdocsign/Program.cs
@@ -153,7 +153,7 @@ class Program
 
             }
             catch(Exception e){
-                throw e;
+                throw;
             }
         }
 


### PR DESCRIPTION
Throwing original exception to keep appropriate stack.