### PR TITLE
Fix version conflicts caused by PR#67

### DIFF
--- a/cli-exakvdocsign/cli-exakvdocsign.csproj
+++ b/cli-exakvdocsign/cli-exakvdocsign.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.16" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.Extensions.Configuration.AzureKeyVault from 3.1.8 to 3.1.16.[(PR#67)](https://github.com/jmhardison/Example-AzureKeyVaultHSM-XMLSigning/pull/67).
Hope this fix can help you.

Best regards,
sucrose